### PR TITLE
updated readme with dev info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ https://trello.com/b/jlViH0QQ/boardwalk-release
 First, make sure you have the [Polymer CLI](https://www.npmjs.com/package/polymer-cli) installed. Then run `polymer serve` to serve your application locally.
 
 ## Viewing the Application
-
 ```
 $ polymer serve
 ```
+## Dev setup
+`npm install`, `bower install` and `polymer serve`

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/swarmcity/sc-boardwalk#readme",
   "dependencies": {
+    "polymer-cli": "^1.1.0",
     "redux": "^3.6.0"
   }
 }


### PR DESCRIPTION
Just made a few small changes so that 
1. `polymer-cli` should be install with `npm install`
2. info on building the dapp for local dev. 