### PR TITLE
ipfs added file size checking

### DIFF
--- a/src/sc-ipfs/sc-ipfs.html
+++ b/src/sc-ipfs/sc-ipfs.html
@@ -51,23 +51,43 @@
       // Returns a Buffer with the IPFS data at that hash.
       // throws on error.
       //
+
+      size: function(hash, cb) {
+        var self = this;
+        this.ipfs.file.ls(hash, function(err, res) {
+          console.log(res);
+          if (res[0][1] < 10000000) {
+            return cb(null);
+          }
+          else {
+            return cb("ipfs hash %s bigger than 10 Mega bytes")
+          }
+        });
+      },
+
       cat: function(hash, cb) {
         var self = this;
-        this.ipfs.cat(hash, function(err, res) {
-          var buf = "";
+        console.log("checking size");
+        size(hash, function (err) {
           if (err) {
             return cb(err);
           }
-          res
-            .on('error', function(err) {
-              throw (err);
-            })
-            .on('data', function(data) {
-              buf += data;
-            })
-            .on('end', function() {
-              return cb(null, buf);
-            });
+          this.ipfs.cat(hash, function(err, res) {
+            var buf = "";
+            if (err) {
+              return cb(err);
+            }
+            res
+              .on('error', function(err) {
+                throw (err);
+              })
+              .on('data', function(data) {
+                buf += data;
+              })
+              .on('end', function() {
+                return cb(null, buf);
+              });
+          });
         });
       },
 


### PR DESCRIPTION
This is a fix that checks the size of a file with ipfs before it starts downloading it. 

I have not been able to test this however. It seems that ipfs function is not called alot due to cacheing. But im going to put this here and check back later. 

https://github.com/swarmcity/sc-boardwalk/issues/230