### PR TITLE
zero out private key before delete

### DIFF
--- a/src/sc-vault/sc-vault.html
+++ b/src/sc-vault/sc-vault.html
@@ -1266,6 +1266,7 @@
 
       deleteVault: function(){
         //debugger;
+        this.privatekey = "0000000000000000000000000000000000000000000000000000000000000000";
         this.privatekey = null;
         this.$.privatekeyinput.inputvalue = null;
         this.$.privatekeyethinput.inputvalue = null;


### PR DESCRIPTION
Where ever the private key is deleted it should be zeroed out first. Otherwise it will still exist in memory. 

If swarm city become successful some people will attack by dumping sections of browsers memory after the dapp is closed. They then test each chunk to see if its the private key of an address that controls funds. This will lead to balance leakage over time.

This PR sets the current private key to string `0000000000000000000000000000000000000000000000000000000000000000` 
1. Is this how the priv key is stored? 
2. Is this the only place where private key is deleted and needs to be overwritten?