### PR TITLE
Fix issue #214, don't ask for backup if restoring from backup

### DIFF
--- a/src/sc-vault/sc-vault.html
+++ b/src/sc-vault/sc-vault.html
@@ -875,12 +875,6 @@
         var self= this;
         this.importipfsstatus = 'downloading';
         this.$.ipfs.cat(this.importipfshash, function(err, data) {
-          try{
-            data = JSON.parse(data);
-          }catch(e){
-            err= e;
-          }
-
           if (err) {
             self.importipfsstatus = 'error';
             self.importipfserrormessage = 'Error downloading IPFS hash: ' + err;


### PR DESCRIPTION
This was working correctly for file restores, but not ipfs.

Changed importipfs function to handle the vault string the same as
reasSingleFile. That is, pass the string into _parseVault, not the
parsed object.

This will allow the _parseVault function to parse the serialized vault
object and calling "setvaultDownloaded" if this is a V1Backup.