### PR TITLE
create a notification when a new chat msg comes in

### DIFF
--- a/src/sc-dealchat/sc-dealchat.html
+++ b/src/sc-dealchat/sc-dealchat.html
@@ -106,11 +106,35 @@ This is dealchat.
         ReduxBehavior
       ],
 
+      actions: {
+        notify: function(notification) {
+            let notifications = this.notifications.slice(0);
+
+            var indexFound = notifications.findIndex(function(item) {
+                return item.id === notification.id;
+            });
+
+            if (indexFound === -1) {
+                notifications.push(notification);
+            }
+
+            return {
+                type: 'NOTIFICATIONS',
+                notifications: notifications
+            };
+        }
+      },
+
       properties: {
 
         identity: {
           type: Object,
           statePath: 'identity',
+        },
+
+        notifications: {
+            type: Array,
+            statePath: 'notifications',
         },
         
         target: {
@@ -127,6 +151,14 @@ This is dealchat.
 
         hashtag: {
           type: String
+        },
+
+        active: {
+          type: Boolean,
+        },
+
+        route: {
+          type: String,
         },
 
       },
@@ -185,6 +217,22 @@ This is dealchat.
           case 'chatmsg':
             this.unshift('chatballoons',payload.msg);
             //this.push('chatballoons',payload.msg);
+
+            if (payload.msg.chatterpubkey !== this.identity.pubkey) {
+                this.dispatch("notify", {
+                    id: this.topic + '_' + payload.msg.chattime,
+                    read: this.active,
+                    msg: 'new chat message from ' + payload.msg.chattername,
+                    timestamp: payload.msg.chattime,
+                    senderidentity: {
+                        username: payload.msg.chattername,
+                        pubkey: payload.msg.chatterpubkey,
+                        avatarhash: payload.msg.chatteravatar
+                    },
+                    hashtag: this.hashtag,
+                    target: this.route.prefix + this.route.path,
+                });
+            }
             break;
         }
       },

--- a/src/sc-dealchat/sc-dealchat.html
+++ b/src/sc-dealchat/sc-dealchat.html
@@ -230,7 +230,7 @@ This is dealchat.
                         avatarhash: payload.msg.chatteravatar
                     },
                     hashtag: this.hashtag,
-                    target: this.route.prefix + this.route.path,
+                    target: this.route.prefix + this.route.path + '/dealchat',
                 });
             }
             break;

--- a/src/sc-dealfortwo/sc-dealfortwo-provider.html
+++ b/src/sc-dealfortwo/sc-dealfortwo-provider.html
@@ -842,7 +842,9 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
       <neon-animatable data-action="dealchat">
         <sc-dealchat
         topic="[[requestdata.id]]"
-        hashtag="[[data.hashtag]]"
+        hashtag="[[requestdata.hashtag]]"
+        active="[[_dealChatSelected(selecteddealpage)]]"
+        route="[[route]]"
         on-back="backfromChat">
         </sc-dealchat>
       </neon-animatable>
@@ -1267,6 +1269,10 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
         this.providerpagesentry = 'slide-from-left-animation';
         this.providerpagesexit = 'slide-right-animation';
         this.selecteddealpage = 'dodeal';
+      },
+
+      _dealChatSelected: function(selectedPage) {
+          return selectedPage === 'dealchat';
       },
 
 

--- a/src/sc-dealfortwo/sc-dealfortwo-provider.html
+++ b/src/sc-dealfortwo/sc-dealfortwo-provider.html
@@ -640,7 +640,8 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
     <sc-hashtagcontract id="hashtagcontract" hashtagcontract="{{routedata.hashtag}}"  loaded="{{hcready}}"></sc-hashtagcontract>
     <iron-media-query query="(min-width:0px) and (max-width: 420px)" query-matches="{{phoneview}}"></iron-media-query>
 
-    <app-route route="{{route}}" pattern="/:hashtag/:requestid/:replyid" data="{{routedata}}"></app-route>
+    <app-route route="{{route}}" pattern="/:hashtag/:requestid/:replyid" data="{{routedata}}" tail="{{page}}"></app-route>
+    <app-route route="{{page}}" pattern="/:page" data="{{pageRouteData}}"></app-route>
     <neon-animated-pages id="providerpages" attr-for-selected="data-action" selected="{{selecteddealpage}}" entry-animation="{{providerpagesentry}}" exit-animation="{{providerpagesexit}}">
 
       <neon-animatable data-action="dodeal">
@@ -880,6 +881,10 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
           type: Object,
           observer: '_route'
         },
+        pageRouteData: {
+          type: Object,
+          observer: '_pageRoute'
+        },
         deals: {
           type: Array,
           statePath: 'deals',
@@ -977,6 +982,13 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
 
       _route: function(){
         this._getdata();
+      },
+
+      _pageRoute: function() {
+        switch (this.pageRouteData.page) {
+          case 'dealchat':
+            this.selecteddealpage = 'dealchat';
+        }
       },
 
       _hashtag: function(){

--- a/src/sc-dealfortwo/sc-dealfortwo-seeker.html
+++ b/src/sc-dealfortwo/sc-dealfortwo-seeker.html
@@ -704,7 +704,8 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
     <iron-media-query query="(min-width:0px) and (max-width: 420px)" query-matches="{{phoneview}}"></iron-media-query>
     <!-- <sc-dealstate deal="{{requestdata}}" dealstate="{{dealstate}}"></sc-dealstate> -->
 
-    <app-route route="{{route}}" pattern="/:hashtag/:requestid/:replyid" data="{{data}}"></app-route>
+    <app-route route="{{route}}" pattern="/:hashtag/:requestid/:replyid" data="{{data}}" tail="{{page}}"></app-route>
+    <app-route route="{{page}}" pattern="/:page" data="{{pageRouteData}}"></app-route>
 
 
         <neon-animated-pages id="seekerpages" attr-for-selected="data-action" selected="{{selecteddealpage}}" entry-animation="{{seekerpagesentry}}" exit-animation="{{seekerpagesexit}}">
@@ -970,6 +971,10 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
           type: Object,
           observer: '_route'
         },
+        pageRouteData: {
+            type: Object,
+            observer: '_pageRoute',
+        },
         deals: {
           type: Array,
           statePath: 'deals',
@@ -1022,6 +1027,13 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
 
       _route: function(){
         this._hashtag();
+      },
+
+      _pageRoute: function() {
+        switch (this.pageRouteData.page) {
+          case 'dealchat':
+            this.selecteddealpage = 'dealchat';
+        }
       },
 
       _hashtag: function(){

--- a/src/sc-dealfortwo/sc-dealfortwo-seeker.html
+++ b/src/sc-dealfortwo/sc-dealfortwo-seeker.html
@@ -894,7 +894,9 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
           <neon-animatable data-action="dealchat">
             <sc-dealchat
             topic="[[requestdata.id]]"
-            hashtag="[[data.hashtag]]"
+            hashtag="[[requestdata.hashtag]]"
+            active="[[_dealChatSelected(selecteddealpage)]]"
+            route="[[route]]"
             on-back="backfromChat">
             </sc-dealchat>
           </neon-animatable>
@@ -1339,6 +1341,10 @@ This components allows 2 Swarm Citizens to make a deal with eachother, based on 
         this.seekerpagesentry = 'slide-from-left-animation';
         this.seekerpagesexit = 'slide-right-animation';
         this.selecteddealpage = 'dodeal';
+      },
+
+      _dealChatSelected: function(selectedPage) {
+        return selectedPage == 'dealchat';
       },
 
       // _dealstate: function(){


### PR DESCRIPTION
partial implementation for #337 

While this still creates a notification if the user is in the chat view, it marks the notification as read. Since whisper messages are constantly propagated for 24 hrs, If I don't add a notification while in the chat view, it will be added when the page is reloaded. I thought the best thing to do would be to add a notification with "read: true".

I'm open for suggestions on ways to improve this.

One thought would be to add a "display" property to notifications. If false, the notification isn't displayed in the notifications view. This would allow users to dismiss individual notifications, so when they view the notifications page next time, they don't see any dismissed notifications. Might reduce the notification clutter for active users